### PR TITLE
Updates for PureScript 0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # purescript-chalk
 
-Bindings to [Chalk](https://github.com/chalk/chalk) and [related](https://github.com/chalk/chalk#related) libraries.
+Bindings to [Chalk](https://github.com/chalk/chalk).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,51 +1,13 @@
-# Module Documentation
+# purescript-chalk
 
-## Module Data.String.Chalk
+Bindings to [Chalk](https://github.com/chalk/chalk) and [related](https://github.com/chalk/chalk#related) libraries.
 
-### Types
+## Installation
 
-    data Style where
-      Bold :: Style
-      Dim :: Style
-      Hidden :: Style
-      Inverse :: Style
-      Italic :: Style
-      Reset :: Style
-      Strikethrough :: Style
-      Underline :: Style
-      Black :: Style
-      Blue :: Style
-      Cyan :: Style
-      Gray :: Style
-      Green :: Style
-      Magenta :: Style
-      Red :: Style
-      White :: Style
-      Yellow :: Style
-      BgBlack :: Style
-      BgBlue :: Style
-      BgCyan :: Style
-      BgGreen :: Style
-      BgMagenta :: Style
-      BgRed :: Style
-      BgWhite :: Style
-      BgYellow :: Style
+```
+bower install purescript-chalk
+```
 
+## Module documentation
 
-### Type Class Instances
-
-    instance showStyle :: Show Style
-
-
-### Values
-
-    chalk :: Style -> String -> String
-
-    chalk' :: [Style] -> String -> String
-
-    hasColor :: String -> Boolean
-
-    stripColor :: String -> String
-
-
-
+- [Data.String.Chalk](docs/Data/String/Chalk.md)

--- a/bower.json
+++ b/bower.json
@@ -6,17 +6,14 @@
   "dependencies": {
     "purescript-prelude": "^0.1.2",
     "purescript-unsafe-coerce": "^0.1.0",
-    "purescript-foldable-traversable": "^0.4.0",
-    "purescript-strings": "^0.7.0",
-    "purescript-quickcheck": "^0.7.0",
-    "purescript-maps": "^0.5.0",
-    "purescript-arrays": "^0.4.2"
+    "purescript-foldable-traversable": "^0.4.0"
   },
   "devDependencies": {
     "purescript-console": "^0.1.0",
     "purescript-spec": "^0.7.1",
-    "purescript-spec-quickcheck": "DavidHarrison/purescript-spec-quickcheck#0cadf4ea6b02ab16945df1e0339c2be1f9242834",
-    "purescript-quickcheck": "^0.9.0",
-    "purescript-arrays": "^0.4.2"
+    "purescript-spec-quickcheck": "DavidHarrison/purescript-spec-quickcheck#0cadf4ea6b02ab16945df1e0339c2be1f9242834"
+  },
+  "resolutions": {
+    "purescript-strings": "^0.7.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,19 @@
   "description": "PureScript wrapper around Chalk.",
   "license": "MIT",
   "dependencies": {
-    "chalk": "~0.5.1"
+    "purescript-prelude": "^0.1.2",
+    "purescript-unsafe-coerce": "^0.1.0",
+    "purescript-foldable-traversable": "^0.4.0",
+    "purescript-strings": "^0.7.0",
+    "purescript-quickcheck": "^0.7.0",
+    "purescript-maps": "^0.5.0",
+    "purescript-arrays": "^0.4.2"
+  },
+  "devDependencies": {
+    "purescript-console": "^0.1.0",
+    "purescript-spec": "^0.7.1",
+    "purescript-spec-quickcheck": "DavidHarrison/purescript-spec-quickcheck#0cadf4ea6b02ab16945df1e0339c2be1f9242834",
+    "purescript-quickcheck": "^0.9.0",
+    "purescript-arrays": "^0.4.2"
   }
 }

--- a/docs/Data/String/Chalk.md
+++ b/docs/Data/String/Chalk.md
@@ -1,0 +1,136 @@
+## Module Data.String.Chalk
+
+#### `hasAnsi`
+
+``` purescript
+hasAnsi :: String -> Boolean
+```
+
+Returns whether the string is styled (contains ANSI codes).
+
+#### `stripAnsi`
+
+``` purescript
+stripAnsi :: String -> String
+```
+
+Removes all styling (ANSI codes) from the string.
+
+#### `ansiRegex`
+
+``` purescript
+ansiRegex :: Regex
+```
+
+Regex for matching ANSI codes.
+
+#### `supportsColor`
+
+``` purescript
+supportsColor :: forall eff. Eff (console :: CONSOLE | eff) Boolean
+```
+
+Return whether the current terminal supports color. The JavaScript Chalk
+automatically prevents styling for terminals not supporting it. This
+has been disabled for this library.
+
+#### `Style`
+
+``` purescript
+data Style
+  = Bold
+  | Dim
+  | Hidden
+  | Inverse
+  | Italic
+  | Reset
+  | Strikethrough
+  | Underline
+  | Black
+  | Blue
+  | Cyan
+  | Gray
+  | Green
+  | Magenta
+  | Red
+  | White
+  | Yellow
+  | BgBlack
+  | BgBlue
+  | BgCyan
+  | BgGreen
+  | BgMagenta
+  | BgRed
+  | BgWhite
+  | BgYellow
+```
+
+##### Instances
+``` purescript
+instance showStyle :: Show Style
+instance arbStyle :: Arbitrary Style
+```
+
+#### `styles`
+
+``` purescript
+styles :: Array Style
+```
+
+All styles excluding `Reset`.
+
+#### `textColors`
+
+``` purescript
+textColors :: Array Style
+```
+
+All text coloring styles.
+
+#### `bgColors`
+
+``` purescript
+bgColors :: Array Style
+```
+
+All background coloring styles.
+
+#### `typeStyles`
+
+``` purescript
+typeStyles :: Array Style
+```
+
+All non-coloring styles, excluding `Reset`.
+
+#### `chalk`
+
+``` purescript
+chalk :: Style -> String -> String
+```
+
+Style a string with the given style. Unlike the JavaScript Chalk, this
+will add the styling regardless of whether it is supported by the current
+terminal. Note that `chalk` is effectful in that it changes its blue color
+depending on whether it is on Windows.
+
+#### `chalk'`
+
+``` purescript
+chalk' :: Array Style -> String -> String
+```
+
+The same as `chalk` but for multiple styles. In case of conflict
+(e.g. multiple colors or a `Reset`), the later style will generally take
+precedence, however both styles are added and so it is dependent on the
+terminal's rendering.
+
+#### `ansiInfo`
+
+``` purescript
+ansiInfo :: Style -> { open :: String, close :: String }
+```
+
+The opening and closing ANSI code for a styles.
+
+

--- a/docs/Data/String/Chalk.md
+++ b/docs/Data/String/Chalk.md
@@ -1,39 +1,5 @@
 ## Module Data.String.Chalk
 
-#### `hasAnsi`
-
-``` purescript
-hasAnsi :: String -> Boolean
-```
-
-Returns whether the string is styled (contains ANSI codes).
-
-#### `stripAnsi`
-
-``` purescript
-stripAnsi :: String -> String
-```
-
-Removes all styling (ANSI codes) from the string.
-
-#### `ansiRegex`
-
-``` purescript
-ansiRegex :: Regex
-```
-
-Regex for matching ANSI codes.
-
-#### `supportsColor`
-
-``` purescript
-supportsColor :: forall eff. Eff (console :: CONSOLE | eff) Boolean
-```
-
-Return whether the current terminal supports color. The JavaScript Chalk
-automatically prevents styling for terminals not supporting it. This
-has been disabled for this library.
-
 #### `Style`
 
 ``` purescript
@@ -79,30 +45,6 @@ styles :: Array Style
 
 All styles excluding `Reset`.
 
-#### `textColors`
-
-``` purescript
-textColors :: Array Style
-```
-
-All text coloring styles.
-
-#### `bgColors`
-
-``` purescript
-bgColors :: Array Style
-```
-
-All background coloring styles.
-
-#### `typeStyles`
-
-``` purescript
-typeStyles :: Array Style
-```
-
-All non-coloring styles, excluding `Reset`.
-
 #### `chalk`
 
 ``` purescript
@@ -124,13 +66,5 @@ The same as `chalk` but for multiple styles. In case of conflict
 (e.g. multiple colors or a `Reset`), the later style will generally take
 precedence, however both styles are added and so it is dependent on the
 terminal's rendering.
-
-#### `ansiInfo`
-
-``` purescript
-ansiInfo :: Style -> { open :: String, close :: String }
-```
-
-The opening and closing ANSI code for a styles.
 
 

--- a/package.json
+++ b/package.json
@@ -12,11 +12,6 @@
     "url": "http://github.com/joneshf/purescript-chalk.git"
   },
   "dependencies": {
-    "chalk": "",
-    "ansi-styles": "",
-    "ansi-regex": "",
-    "strip-ansi": "",
-    "has-ansi": "",
-    "supports-color": ""
+    "chalk": ""
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,11 +7,16 @@
     "gulp": "^3.8.6",
     "gulp-purescript": "0.0.9"
   },
-  "peerDependencies": {
-    "chalk": "^0.x"
-  },
   "repository": {
     "type": "git",
     "url": "http://github.com/joneshf/purescript-chalk.git"
+  },
+  "dependencies": {
+    "chalk": "",
+    "ansi-styles": "",
+    "ansi-regex": "",
+    "strip-ansi": "",
+    "has-ansi": "",
+    "supports-color": ""
   }
 }

--- a/src/Data/String/Chalk.js
+++ b/src/Data/String/Chalk.js
@@ -8,18 +8,6 @@ exports.localChalk = (function() {
   return new chalk.constructor({enabled: true});
 })();
 
-exports.ansiStyles = require('ansi-styles');
-
-exports.stripAnsi = require('strip-ansi');
-
-exports.hasAnsi = require('has-ansi');
-
-exports.ansiRegex = require('ansi-regex')();
-
-exports.supportsColor = function() {
-  return require('supports-color')
-}
-
 exports.unsafeGet = function(prop) {
   return function(obj) {
     return obj[prop];

--- a/src/Data/String/Chalk.js
+++ b/src/Data/String/Chalk.js
@@ -1,0 +1,27 @@
+/* global exports */
+"use strict";
+
+// module Data.String.Chalk
+
+exports.localChalk = (function() {
+  var chalk = require('chalk');
+  return new chalk.constructor({enabled: true});
+})();
+
+exports.ansiStyles = require('ansi-styles');
+
+exports.stripAnsi = require('strip-ansi');
+
+exports.hasAnsi = require('has-ansi');
+
+exports.ansiRegex = require('ansi-regex')();
+
+exports.supportsColor = function() {
+  return require('supports-color')
+}
+
+exports.unsafeGet = function(prop) {
+  return function(obj) {
+    return obj[prop];
+  }
+}

--- a/src/Data/String/Chalk.purs
+++ b/src/Data/String/Chalk.purs
@@ -1,27 +1,15 @@
 module Data.String.Chalk
   ( Style(..)
   , styles
-  , textColors
-  , bgColors
-  , typeStyles
   , chalk
   , chalk'
-  , hasAnsi
-  , stripAnsi
-  , ansiRegex
-  , supportsColor
-  , ansiInfo
   ) where
 
 import Prelude
 
-import Control.Monad.Eff         (Eff())
-import Control.Monad.Eff.Console (CONSOLE())
 import Data.Array                (uncons)
 import Data.Foldable             (foldl)
 import Data.Maybe                (Maybe(..))
-import Data.String.Regex         (Regex())
-import Data.StrMap               (StrMap())
 import Unsafe.Coerce             (unsafeCoerce)
 import Test.QuickCheck.Arbitrary (Arbitrary, arbitrary)
 import Test.QuickCheck.Gen       (elements)
@@ -31,23 +19,6 @@ foreign import data Builder :: *
 
 -- Internal
 foreign import localChalk :: Chalk
-
--- Internal
-foreign import ansiStyles :: StrMap { open :: String, close :: String }
-
--- | Returns whether the string is styled (contains ANSI codes).
-foreign import hasAnsi :: String -> Boolean
-
--- | Removes all styling (ANSI codes) from the string.
-foreign import stripAnsi :: String -> String
-
--- | Regex for matching ANSI codes.
-foreign import ansiRegex :: Regex
-
--- | Return whether the current terminal supports color. The JavaScript Chalk
--- | automatically prevents styling for terminals not supporting it. This
--- | has been disabled for this library.
-foreign import supportsColor :: forall eff. Eff (console :: CONSOLE | eff) Boolean
 
 -- Internal
 foreign import unsafeGet :: forall o a. String -> o -> a
@@ -118,11 +89,6 @@ chalk' stys str = case uncons stys of
                      let iter = flip styleBuilder
                          init = mkBuilder x.head localChalk
                       in build (foldl iter init x.tail) str
-
-
--- | The opening and closing ANSI code for a styles.
-ansiInfo :: Style -> { open :: String, close :: String }
-ansiInfo style = unsafeGet (show style) ansiStyles
 
 -- Instances ------------------------------------------------------------------
 instance showStyle :: Show Style where

--- a/src/Data/String/Chalk.purs
+++ b/src/Data/String/Chalk.purs
@@ -1,98 +1,166 @@
 module Data.String.Chalk
   ( Style(..)
+  , styles
+  , textColors
+  , bgColors
+  , typeStyles
   , chalk
   , chalk'
-  , hasColor
-  , stripColor
+  , hasAnsi
+  , stripAnsi
+  , ansiRegex
+  , supportsColor
+  , ansiInfo
   ) where
 
-  import Debug.Trace
+import Prelude
 
-  foreign import localChalk "var localChalk = require('chalk');" :: Unit
+import Control.Monad.Eff         (Eff())
+import Control.Monad.Eff.Console (CONSOLE())
+import Data.Array                (uncons)
+import Data.Foldable             (foldl)
+import Data.Maybe                (Maybe(..))
+import Data.String.Regex         (Regex())
+import Data.StrMap               (StrMap())
+import Unsafe.Coerce             (unsafeCoerce)
+import Test.QuickCheck.Arbitrary (Arbitrary, arbitrary)
+import Test.QuickCheck.Gen       (elements)
 
-             -- | General
-  data Style = Bold
-             | Dim
-             | Hidden
-             | Inverse
-             | Italic -- (not widely supported)
-             | Reset
-             | Strikethrough -- (not widely supported)
-             | Underline
-             -- | Text colors
-             | Black
-             | Blue
-             | Cyan
-             | Gray
-             | Green
-             | Magenta
-             | Red
-             | White
-             | Yellow
-             -- | Background colors
-             | BgBlack
-             | BgBlue
-             | BgCyan
-             | BgGreen
-             | BgMagenta
-             | BgRed
-             | BgWhite
-             | BgYellow
+foreign import data Chalk :: *
+foreign import data Builder :: *
 
-  instance showStyle :: Show Style where
-    show BgBlack       = "bgblack"
-    show BgBlue        = "bgblue"
-    show BgCyan        = "bgcyan"
-    show BgGreen       = "bggreen"
-    show BgMagenta     = "bgmagenta"
-    show BgRed         = "bgred"
-    show BgWhite       = "bgwhite"
-    show BgYellow      = "bgyellow"
-    show Black         = "black"
-    show Blue          = "blue"
-    show Bold          = "bold"
-    show Cyan          = "cyan"
-    show Dim           = "dim"
-    show Gray          = "gray"
-    show Green         = "green"
-    show Hidden        = "hidden"
-    show Inverse       = "inverse"
-    show Italic        = "italic"
-    show Magenta       = "magenta"
-    show Red           = "red"
-    show Reset         = "reset"
-    show Strikethrough = "strikethrough"
-    show Underline     = "underline"
-    show White         = "white"
-    show Yellow        = "yellow"
+-- Internal
+foreign import localChalk :: Chalk
 
-  chalk :: Style -> String -> String
-  chalk style string = unsafeChalk [style] string
+-- Internal
+foreign import ansiStyles :: StrMap { open :: String, close :: String }
 
-  chalk' :: [Style] -> String -> String
-  chalk' styles string = unsafeChalk styles string
+-- | Returns whether the string is styled (contains ANSI codes).
+foreign import hasAnsi :: String -> Boolean
 
-  hasColor :: String -> Boolean
-  hasColor string = unsafeCallChalk "hasColor" string
+-- | Removes all styling (ANSI codes) from the string.
+foreign import stripAnsi :: String -> String
 
-  stripColor :: String -> String
-  stripColor string = unsafeCallChalk "stripColor" string
+-- | Regex for matching ANSI codes.
+foreign import ansiRegex :: Regex
 
-  showStyle_ :: Style -> String
-  showStyle_ = show
+-- | Return whether the current terminal supports color. The JavaScript Chalk
+-- | automatically prevents styling for terminals not supporting it. This
+-- | has been disabled for this library.
+foreign import supportsColor :: forall eff. Eff (console :: CONSOLE | eff) Boolean
 
-  foreign import unsafeChalk
-    "function unsafeChalk(styles) {\
-    \  return function(string) {\
-    \    return styles.reduce(function(chalk, style) {\
-    \      return chalk[showStyle_(style)];\
-    \    }, localChalk)(string);\
-    \  }\
-    \}" :: [Style] -> String -> String
+-- Internal
+foreign import unsafeGet :: forall o a. String -> o -> a
 
-  foreign import unsafeCallChalk
-    "function unsafeCallChalk(method) {\
-    \  return function(x) {\
-    \    return localChalk[method](x);\
-    \  }\
-    \}" :: forall a b. String -> a -> b
+-- | ANSI styles supported by Chalk. `Italic` and `Strikethrough` are not
+-- | widely supported and `Blue` and `BgBlue` will automatically be changed
+-- | to light blue on Windows for legibility.
+           -- General
+data Style = Bold
+           | Dim
+           | Hidden
+           | Inverse
+           | Italic -- (not widely supported)
+           | Reset
+           | Strikethrough -- (not widely supported)
+           | Underline
+           -- Text colors
+           | Black
+           | Blue
+           | Cyan
+           | Gray
+           | Green
+           | Magenta
+           | Red
+           | White
+           | Yellow
+           -- Background colors
+           | BgBlack
+           | BgBlue
+           | BgCyan
+           | BgGreen
+           | BgMagenta
+           | BgRed
+           | BgWhite
+           | BgYellow
+
+-- | All styles excluding `Reset`.
+styles :: Array Style
+styles = textColors <> bgColors <> typeStyles
+
+-- | All text coloring styles.
+textColors :: Array Style
+textColors = [Black, Blue, Cyan, Gray, Green, Magenta, Red, White, Yellow]
+
+-- | All background coloring styles.
+bgColors :: Array Style
+bgColors = [BgBlack, BgBlue, BgCyan, BgGreen, BgMagenta, BgRed, BgWhite, BgYellow]
+
+-- | All non-coloring styles, excluding `Reset`.
+typeStyles :: Array Style
+typeStyles = [Bold, Dim, Hidden, Inverse, Italic, Strikethrough, Underline]
+
+-- | Style a string with the given style. Unlike the JavaScript Chalk, this
+-- | will add the styling regardless of whether it is supported by the current
+-- | terminal. Note that `chalk` is effectful in that it changes its blue color
+-- | depending on whether it is on Windows.
+chalk :: Style -> String -> String
+chalk style = build (mkBuilder style localChalk)
+
+-- | The same as `chalk` but for multiple styles. In case of conflict
+-- | (e.g. multiple colors or a `Reset`), the later style will generally take
+-- | precedence, however both styles are added and so it is dependent on the
+-- | terminal's rendering.
+chalk' :: Array Style -> String -> String
+chalk' stys str = case uncons stys of
+                   Nothing -> str
+                   Just x ->
+                     let iter = flip styleBuilder
+                         init = mkBuilder x.head localChalk
+                      in build (foldl iter init x.tail) str
+
+
+-- | The opening and closing ANSI code for a styles.
+ansiInfo :: Style -> { open :: String, close :: String }
+ansiInfo style = unsafeGet (show style) ansiStyles
+
+-- Instances ------------------------------------------------------------------
+instance showStyle :: Show Style where
+  show BgBlack       = "bgBlack"
+  show BgBlue        = "bgBlue"
+  show BgCyan        = "bgCyan"
+  show BgGreen       = "bgGreen"
+  show BgMagenta     = "bgMagenta"
+  show BgRed         = "bgRed"
+  show BgWhite       = "bgWhite"
+  show BgYellow      = "bgYellow"
+  show Black         = "black"
+  show Blue          = "blue"
+  show Bold          = "bold"
+  show Cyan          = "cyan"
+  show Dim           = "dim"
+  show Gray          = "gray"
+  show Green         = "green"
+  show Hidden        = "hidden"
+  show Inverse       = "inverse"
+  show Italic        = "italic"
+  show Magenta       = "magenta"
+  show Red           = "red"
+  show Reset         = "reset"
+  show Strikethrough = "strikethrough"
+  show Underline     = "underline"
+  show White         = "white"
+  show Yellow        = "yellow"
+
+instance arbStyle :: Arbitrary Style where
+  arbitrary = elements Reset styles
+
+-- Builder Functions ----------------------------------------------------------
+mkBuilder :: Style -> Chalk -> Builder
+mkBuilder style chlk = unsafeGet (show style) chlk
+
+styleBuilder :: Style -> Builder -> Builder
+styleBuilder style builder = unsafeGet (show style) builder
+
+build :: Builder -> String -> String
+build = unsafeCoerce

--- a/test/Main.js
+++ b/test/Main.js
@@ -1,0 +1,14 @@
+/* global exports */
+"use strict";
+
+// module Test.Main
+
+exports.escape = JSON.stringify
+
+exports.truthy = function(x) {
+  if (x) {
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/test/Main.js
+++ b/test/Main.js
@@ -3,8 +3,6 @@
 
 // module Test.Main
 
-exports.escape = JSON.stringify
-
 exports.truthy = function(x) {
   if (x) {
     return true;

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,126 @@
+module Test.Main where
+
+import Prelude
+
+import Control.Monad.Aff          (Aff())
+import Control.Monad.Eff          (Eff())
+import Control.Monad.Eff.Console  (log)
+import Data.Array                 (length)
+import Data.Maybe                 (Maybe(..))
+import Data.String.Regex          (Regex(), match, regex, noFlags, replace)
+import Data.Traversable           (traverse)
+import Test.Spec                  (describe, it)
+import Test.Spec.Runner           (run)
+import Test.Spec.Reporter.Console (consoleReporter)
+import Test.Spec.QuickCheck       (quickCheck)
+import Test.QuickCheck            (Result(..), (===), (<?>))
+
+import Data.String.Chalk
+
+main = do
+  traverse (log <<< someText) styles
+  log $ chalk Reset $ chalk Bold "Here is some reset bold text"
+  log $ chalk Bold $ chalk Reset "Here is some reset bold text"
+  log $ chalk' [Reset, Bold] "Here is some reset bold text"
+  log $ chalk' [Bold, Reset] "Here is some reset bold text"
+  log $ chalk' [Bold, Underline] "Here is some bold, underlined, text"
+  log ""
+  supportsColor >>= (log <<< append "Terminal supports color: " <<< show)
+  log ""
+  traverse (log <<< info) styles
+  run [consoleReporter] $ do
+    describe "styles" do
+      it "exists" do
+        quickCheck (truthy styles)
+    describe "textColors" $ do
+      it "exists" do
+        quickCheck (truthy textColors)
+    describe "bgColors" do
+      it "exists" do
+        quickCheck (truthy bgColors)
+    describe "typeStyles" do
+      it "exists" do
+        quickCheck (truthy typeStyles)
+    describe "chalk" do
+      it "exists" do
+        quickCheck (truthy chalk)
+      it "is total" do
+        quickCheck \sty str -> const true (chalk sty str)
+      it "adds ANSI codes" do
+        quickCheck \sty str ->
+          let codePatt = regexStr ansiRegex
+              patt = regex (codePatt <> str <> codePatt) noFlags
+          in if str /= ""
+                then chalk sty str `matches` patt
+                else Success
+    describe "chalk'" do
+      it "exists" do
+        quickCheck (truthy chalk')
+      it "is total" do
+        quickCheck \stys str -> const true (chalk' stys str)
+    describe "hasAnsi" do
+      it "exists" do
+        quickCheck (truthy hasAnsi)
+      it "is total" do
+        quickCheck \str -> const true (hasAnsi str)
+      it "detects ANSI codes when present" do
+        quickCheck \stys str ->
+          let shouldHave = (length stys > 0) && str /= ""
+              res = hasAnsi (chalk' stys str) == shouldHave
+              exp = "stys: " <> show stys <> " string: " <> escape str
+           in res <?> exp
+    describe "stripAnsi" do
+      it "exists" do
+        quickCheck (truthy stripAnsi)
+      it "is total" do
+        quickCheck \str -> const true (stripAnsi str)
+      it "removes codes added by chalk'" do
+        quickCheck \stys str ->
+          stripAnsi (chalk' stys str) === str
+    describe "ansiRegex" do
+      it "exists" do
+        quickCheck (truthy ansiRegex)
+      it "matches codes where present" do
+        quickCheck \stys str ->
+          let shouldHave = (length stys > 0) && str /= ""
+              str' = chalk' stys str
+           in if shouldHave
+                 then str' `matches` ansiRegex
+                 else str' `noMatch` ansiRegex
+    describe "supportsColor" do
+      it "exists" do
+        quickCheck (truthy supportsColor)
+    describe "ansiInfo" do
+      it "exists" do
+        quickCheck (truthy ansiInfo)
+      it "has valid codes" do
+        quickCheck \sty ->
+          let inf = ansiInfo sty
+           in (hasAnsi inf.open && hasAnsi inf.close) <?> "style: " <> show sty
+
+foreign import truthy :: forall a. a -> Boolean
+foreign import escape :: String -> String
+
+someText :: Style -> String
+someText style = chalk style $ "Here is some " <> show style <> " text"
+
+info :: Style -> String
+info style = show style
+          <> " open: " <> escape inf.open
+          <> " close: " <> escape inf.close
+  where inf = ansiInfo style
+
+regexStr :: Regex -> String
+regexStr = cutBack <<< cutFront <<< show
+  where cutFront = replace (regex "^.*?/" noFlags) ""
+        cutBack  = replace (regex "/.*?$" noFlags) ""
+
+matches :: String -> Regex -> Result
+matches str patt = case match patt str of
+  Nothing -> Failed ("Could not match " <> escape str <> " with " <> show patt)
+  Just _  -> Success
+
+noMatch :: String -> Regex -> Result
+noMatch str patt = case match patt str of
+  Nothing -> Success
+  Just _  -> Failed (escape str <> " should not match " <> show patt)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,18 +2,12 @@ module Test.Main where
 
 import Prelude
 
-import Control.Monad.Aff          (Aff())
-import Control.Monad.Eff          (Eff())
 import Control.Monad.Eff.Console  (log)
-import Data.Array                 (length)
-import Data.Maybe                 (Maybe(..))
-import Data.String.Regex          (Regex(), match, regex, noFlags, replace)
 import Data.Traversable           (traverse)
 import Test.Spec                  (describe, it)
 import Test.Spec.Runner           (run)
 import Test.Spec.Reporter.Console (consoleReporter)
 import Test.Spec.QuickCheck       (quickCheck)
-import Test.QuickCheck            (Result(..), (===), (<?>))
 
 import Data.String.Chalk
 
@@ -25,102 +19,22 @@ main = do
   log $ chalk' [Bold, Reset] "Here is some reset bold text"
   log $ chalk' [Bold, Underline] "Here is some bold, underlined, text"
   log ""
-  supportsColor >>= (log <<< append "Terminal supports color: " <<< show)
-  log ""
-  traverse (log <<< info) styles
   run [consoleReporter] $ do
     describe "styles" do
       it "exists" do
         quickCheck (truthy styles)
-    describe "textColors" $ do
-      it "exists" do
-        quickCheck (truthy textColors)
-    describe "bgColors" do
-      it "exists" do
-        quickCheck (truthy bgColors)
-    describe "typeStyles" do
-      it "exists" do
-        quickCheck (truthy typeStyles)
     describe "chalk" do
       it "exists" do
         quickCheck (truthy chalk)
       it "is total" do
         quickCheck \sty str -> const true (chalk sty str)
-      it "adds ANSI codes" do
-        quickCheck \sty str ->
-          let codePatt = regexStr ansiRegex
-              patt = regex (codePatt <> str <> codePatt) noFlags
-          in if str /= ""
-                then chalk sty str `matches` patt
-                else Success
     describe "chalk'" do
       it "exists" do
         quickCheck (truthy chalk')
       it "is total" do
         quickCheck \stys str -> const true (chalk' stys str)
-    describe "hasAnsi" do
-      it "exists" do
-        quickCheck (truthy hasAnsi)
-      it "is total" do
-        quickCheck \str -> const true (hasAnsi str)
-      it "detects ANSI codes when present" do
-        quickCheck \stys str ->
-          let shouldHave = (length stys > 0) && str /= ""
-              res = hasAnsi (chalk' stys str) == shouldHave
-              exp = "stys: " <> show stys <> " string: " <> escape str
-           in res <?> exp
-    describe "stripAnsi" do
-      it "exists" do
-        quickCheck (truthy stripAnsi)
-      it "is total" do
-        quickCheck \str -> const true (stripAnsi str)
-      it "removes codes added by chalk'" do
-        quickCheck \stys str ->
-          stripAnsi (chalk' stys str) === str
-    describe "ansiRegex" do
-      it "exists" do
-        quickCheck (truthy ansiRegex)
-      it "matches codes where present" do
-        quickCheck \stys str ->
-          let shouldHave = (length stys > 0) && str /= ""
-              str' = chalk' stys str
-           in if shouldHave
-                 then str' `matches` ansiRegex
-                 else str' `noMatch` ansiRegex
-    describe "supportsColor" do
-      it "exists" do
-        quickCheck (truthy supportsColor)
-    describe "ansiInfo" do
-      it "exists" do
-        quickCheck (truthy ansiInfo)
-      it "has valid codes" do
-        quickCheck \sty ->
-          let inf = ansiInfo sty
-           in (hasAnsi inf.open && hasAnsi inf.close) <?> "style: " <> show sty
 
 foreign import truthy :: forall a. a -> Boolean
-foreign import escape :: String -> String
 
 someText :: Style -> String
 someText style = chalk style $ "Here is some " <> show style <> " text"
-
-info :: Style -> String
-info style = show style
-          <> " open: " <> escape inf.open
-          <> " close: " <> escape inf.close
-  where inf = ansiInfo style
-
-regexStr :: Regex -> String
-regexStr = cutBack <<< cutFront <<< show
-  where cutFront = replace (regex "^.*?/" noFlags) ""
-        cutBack  = replace (regex "/.*?$" noFlags) ""
-
-matches :: String -> Regex -> Result
-matches str patt = case match patt str of
-  Nothing -> Failed ("Could not match " <> escape str <> " with " <> show patt)
-  Just _  -> Success
-
-noMatch :: String -> Regex -> Result
-noMatch str patt = case match patt str of
-  Nothing -> Success
-  Just _  -> Failed (escape str <> " should not match " <> show patt)


### PR DESCRIPTION
- Move FFI code into separate JavaScript file
- Add functions from related/sub-libraries
- Enable styling regardless of whether support is detected for the current terminal (it is not when testing with Pulp)
- Add tests (can be run with Pulp)
- Generate docs with Pulp

One outstanding issue is that `chalk` and `chalk'` are still effectful since they change `blue`/`bgBlue` to light blue on Windows for legibility. This setting is not exposed in the Chalk API.

Thanks!
